### PR TITLE
Update spec status from "Unofficial" to "Draft CG Report"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Local Network Access
 Shortname: LNA
 Level: None
-Status: w3c/UD
+Status: w3c/CG-DRAFT
 Repository: WICG/local-network-access
 URL: https://wicg.github.io/local-network-access/
 Editor: Chris Thompson, Google https://google.com, cthomp@google.com


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/1953

The "Unofficial" status signals that the spec has no official standing whatsoever. Tools that process specs typically skip such specs (or flag them as pending).

The spec was adopted by the WICG, which at least signals some level of support among interested parties. This update bumps the status to the more usual "Draft CG Report" status so that data can start referencing the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/local-network-access/pull/39.html" title="Last updated on Aug 20, 2025, 9:04 AM UTC (7b6e185)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/local-network-access/39/83b724a...tidoust:7b6e185.html" title="Last updated on Aug 20, 2025, 9:04 AM UTC (7b6e185)">Diff</a>