### PR TITLE
Refactor local network requests ISSUE 1 into separate blocks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -448,17 +448,21 @@ ISSUE: The definition of [=local network requests=] could be expanded to cover
 all cross-origin requests for which the [=request/current url=]'s {{URL/host}}
 maps to an IP address whose [=/IP address space=] is not [=IP address
 space/public=]. This would prevent a malicious server on the local network from
-attacking other servers, including servers on `localhost`. Currently, Chromium
-only implements Local Network Access restrictions for [=IP address
-space/public=] to [=IP address space/local=] or [=IP address space/loopback=]
-requests, and does not enforce the permission for cross-origin [=IP address
-space/local=] requests. This can be shipped as an incremental improvement later
-on. See <WICG/private-network-access#39>. We note that, because local names and
-addresses are not meaningful outside the bounds of the network, implementers
-may want to use a different permission prompt for the cross-origin [=IP address
-space/local=] case than for the [=IP address space/public=] to [=IP address
-space/local=] case, and may want to scope these permission grants to the
-specific network or to the current browsing session only.
+attacking other servers, including servers on `localhost`. See
+<WICG/private-network-access#39>.
+
+NOTE: Currently, Chromium only implements Local Network Access restrictions for
+[=IP address space/public=] to [=IP address space/local=] or [=IP address
+space/loopback=] requests, and does not enforce the permission for cross-origin
+[=IP address space/local=] requests. This restriction can be shipped as an
+incremental improvement in future implementations.
+
+NOTE: Because local names and addresses are not meaningful outside the bounds of
+the network, implementers might want to use a different permission prompt for the
+cross-origin [=IP address space/local=] case than for the [=IP address
+space/public=] to [=IP address space/local=] case. Additionally, implementers
+might want to scope these permission grants to the specific network or to the
+current browsing session only.
 
 NOTE: Some [=local network requests=] are more challenging to secure than others.
 See [[#rollout-difficulties]] for more details.


### PR DESCRIPTION
Split the monolithic ISSUE about expanding local network request definitions into one ISSUE and two NOTE blocks for better clarity:

- ISSUE: Core specification gap about covering all cross-origin non-public requests
- NOTE: Current Chromium implementation scope and incremental shipping strategy
- NOTE: Implementation considerations for permission prompts and scoping

Changed 'may' to 'might' in NOTE sections to avoid RFC2119 keywords in non-normative text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MayyaSunil/local-network-access/pull/50.html" title="Last updated on Oct 16, 2025, 7:48 PM UTC (5527431)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/local-network-access/50/67254f5...MayyaSunil:5527431.html" title="Last updated on Oct 16, 2025, 7:48 PM UTC (5527431)">Diff</a>