### PR TITLE
Add Permissions Policy integration with "allowed to use" check

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,6 +19,10 @@ Include Can I Use Panels: yes
 Indent: 2
 </pre>
 
+<pre class=link-defaults>
+spec:dom; type:dfn; text:document
+</pre>
+
 <pre class="anchors">
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: abstract-op
@@ -39,6 +43,9 @@ url: https://websockets.spec.whatwg.org/#concept-websocket-connection-obtain; ty
 spec: WEBSOCKET; urlPrefix: https://websockets.spec.whatwg.org/
   type: abstract-op;
     text: WebSocket opening handshake; url: #websocket-opening-handshake
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html
+  type: dfn; for: global object
+    text: associated Document; url: #concept-document-window
 </pre>
 
 <pre class="biblio">
@@ -666,15 +673,47 @@ Update [[FETCH]] as follows:
 
               3.  Set |error|'s [=response/IP address=] property to |address|.
 
-              4.  TODO: Permission check is sketched out below, wording is still vague.
-                  See <wicg/local-network-access#59>.
-                  1. If the initiating origin has been granted the local
-                     network access permission, return null.
-                  2. If the initiating origin has been denied the local network
-                     access permission, return |error|.
-                  3. Otherwise, prompt the user:
-                     1. If the user grants permission, return null.
-                     2. If the user denies the permission, return |error|.
+              4.  Let |permissionName| be "local-network" if |addressSpace|
+                  is [=IP address space/local=], or "loopback-network" if
+                  |addressSpace| is [=IP address space/loopback=].
+
+              5.  Let |settingsObject| be |request|'s [=request/client=].
+
+              6.  Let |global| be |settingsObject|'s [=environment settings
+                  object/global object=].
+
+              7.  Let |document| be |global|'s [=global object/associated
+                  Document=].
+
+              8.  If |document| is null, then return |error|.
+
+                  NOTE: This step will cause local network requests from Service
+                  Workers to fail, as Service Workers do not always have an
+                  associated Document. Future versions of this specification need
+                  to define how to handle Workers, particularly since Permissions
+                  Policy is not yet supported in Workers. See
+                  [w3c/webappsec-permissions-policy#207](https://github.com/w3c/webappsec-permissions-policy/issues/207).
+
+                  ISSUE: Define local network access behavior for Service Workers.
+
+              9.  If |document| is not [=allowed to use=]
+                  |permissionName|, then return |error|.
+
+              10. Let |permissionState| be the result of [=getting the current
+                  permission state=] given |permissionName| and |global|.
+
+              11. If |permissionState| is [=permission/denied=], then return
+                  |error|.
+
+              12. If |permissionState| is [=permission/granted=], then return
+                  null.
+
+              13. [=Prompt the user to choose=] whether to grant
+                  |permissionName| for |global|:
+
+                  1.  If the user grants permission, then return null.
+
+                  2.  If the user denies permission, then return |error|.
       1.  Return null.
 
   1.  The [$fetch$] algorithm is amended to add 2 new steps right after |request|’s


### PR DESCRIPTION
Resolves issue #37 by adding proper Permissions Policy integration to the Local Network Access check algorithm

Changes:
- Replace TODO with normative algorithm steps for permission checking in the Local Network Access check algorithm
- Add "allowed to use" check to verify the "local-network-access" policy-controlled feature is allowed before checking permission state (refer [comment](https://github.com/WICG/local-network-access/issues/37#issuecomment-3269472032))
- Add anchor definition for HTML spec's "associated Document" term


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 15, 2026, 1:05 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Flocal-network-access%2Fbdaf287d700b0123a9cd8eae68537ecd9677c7c3%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "917:6",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=Document=]"
    },
    {
        "lineNum": "918:53",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=Document=]"
    },
    {
        "lineNum": "921:5",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=Document=]"
    },
    {
        "lineNum": "946:3",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=document=]"
    },
    {
        "lineNum": "948:1",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=document=]"
    },
    {
        "lineNum": "950:43",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=document=]"
    },
    {
        "lineNum": "957:45",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=document=]"
    },
    {
        "lineNum": "964:45",
        "messageType": "link",
        "text": "Multiple possible 'document' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-document\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:document\nspec:css-style-attr; type:dfn; text:document\n[=document=]"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20WICG/local-network-access%2359.)._

</details>
