### PR TITLE
Split permission into "local-network" and "loopback-network"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -549,14 +549,21 @@ normative references.
 
 ## Integration with Permissions ## {#integration-with-permissions}
 
-This document defines a [=default powerful feature=] identified by the [=powerful
-feature/name=] <dfn export permission>`"local-network-access"`</dfn>.
+This document defines two new [=default powerful feature=]s identified by the [=powerful
+feature/name=]s <dfn export permission>`"local-network"`</dfn> and
+<dfn export permission>`"loopback-network"`</dfn>.
+
+NOTE: Previously, the permission was specified as a single feature that covered
+both local and loopback cases.
 
 ## Integration with Permissions Policy ## {#integration-with-permissions-policy}
 
-Local Network Access defines a [=policy-controlled feature=] identified by the
-string "local-network-access". Its [=policy-controlled feature/default allowlist=]
-is `'self'`.
+Local Network Access defines two [=policy-controlled feature=]s identified by the
+strings "local-network" and "loopback-network". The
+[=policy-controlled feature/default allowlist=] for each is `'self'`.
+
+NOTE: Previously, the policy controlled feature was specified as a single feature
+that covered both local and loopback cases.
 
 ## Integration with Fetch ## {#integration-with-fetch}
 


### PR DESCRIPTION
This updates the spec based on the discussion in #17, and should help unblock expanding out the "check permission" part of the spec in the Fetch integration (#59).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/local-network-access/pull/87.html" title="Last updated on Jan 8, 2026, 7:57 PM UTC (f7e5740)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/local-network-access/87/3def5d2...f7e5740.html" title="Last updated on Jan 8, 2026, 7:57 PM UTC (f7e5740)">Diff</a>