### PR TITLE
remove service worker navigate issue

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/index.bs
+++ b/index.bs
@@ -904,16 +904,6 @@ container](https://fetch.spec.whatwg.org/#concept-request-policy-container)
 during [fetch](https://fetch.spec.whatwg.org/#concept-fetch). See
 <WICG/private-network-access#83>.
 
-ISSUE: The [Service
-Worker](https://w3c.github.io/ServiceWorker/#dfn-service-worker)
-[navigate](https://w3c.github.io/ServiceWorker/#client-navigate) algorithm is
-defined by the
-[navigate](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate)
-algorithm in the HTML spec; neither navigate algorithm mentions the local
-network access algorithm in it. The Service Worker navigate spec will need to
-be updated to include the local network access check based on the
-WindowClient's policy container, not the Service Worker's policy container.
-
 # Implementation considerations # {#implementation-considerations}
 
 ## File URLs ## {#file-urls}


### PR DESCRIPTION
it was determined that the service worker navigate spec doesn't need modification and is correct as is.