### PR TITLE
Add targetAddressSpace integration in WebSockets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -821,13 +821,41 @@ upgrading in step 1:
 
 WebSockets connections should be subject to the same local network access
 permission requirements.  [$WebSocket opening handshake$] directly applies
-[$fetch$] in step 11, and so no modification to the WebSocket specification is
+[$fetch$] in step 11, and so for enforcement no modification to the WebSocket specification is
 required beyond the fetch change proposed above.
 
-One minor difference between the Fetch API and the WebSockets API is that
-WebSockets does not have an equivalent to fetch's `RequestInit`, and so there
-is no place to put in a `targetAddressSpace` option to bypass mixed content
-checks for ws:// urls.
+To support the targetAddressSpace option, the WebSockets spec needs to be adjusted.
+
+  * Append an optional [=map/entry=] to {{WebSocketInit}}, whose [=map/key=] is
+    <dfn export>targetAddressSpace</dfn>, and [=map/value=] is a
+    {{IPAddressSpace}}.
+      <pre class="idl">
+        partial dictionary WebSocketInit {
+          IPAddressSpace targetAddressSpace;
+        };
+      </pre>
+
+  * Update <a algorithm="establish a WebSocket connection">establish a WebSocket connection</a>
+    to additionally take a targetAddressSpace parameter, and then when constructing the
+    [=request=] |request| in step 2, set |request|'s targetAddressSpace to targetAddressSpace.
+
+  * Add the following steps to <a constructor for=WebSocket lt="WebSocket(url, protocolsOrOptions)">
+    <code>new WebSocket(<var ignore=''>url</var>, |protocolsOrOptions|)</code></a> after the steps
+    for handling protocols:
+    1. Let |targetAddressSpace| be an [=IP address space=], initially null.
+    1.  If |protocolsOrOptions|["{{WebSocketInit/targetAddressSpace}}"] [=map/exists=], then
+        switch on |protocolsOrOptions|["{{WebSocketInit/targetAddressSpace}}"]:
+        <dl class=switch>
+          <dt>public
+            <dd>Do nothing.
+          
+          <dt>local
+          <dd>Set |targetAddressSpace| to [=IP address space/local=].
+        </dl>
+
+  * Update the last step of <a constructor for=WebSocket lt="WebSocket(url, protocolsOrOptions)">
+    <code>new WebSocket(<var ignore=''>url</var>, |protocolsOrOptions|)</code></a> to:
+    1. [=Establish a WebSocket connection=] given |urlRecord|, |protocols|, |targetAddressSpace|, and |client|.
 
 ## Integration with WebTransport ## {#integration-with-webtransport}
 

--- a/index.bs
+++ b/index.bs
@@ -800,6 +800,9 @@ The Fetch API needs to be adjusted as well.
           <dt>local
           <dd>Set |request|'s targetAddressSpace to [=IP address
             space/local=].
+          <dt>loopback
+          <dd>Set |request|'s targetAddressSpace to [=IP address
+            space/loopback=].
         </dl>
 
 ## Integration with Mixed Content ## {#integration-with-mixed-content}
@@ -826,8 +829,11 @@ required beyond the fetch change proposed above.
 
 To support the targetAddressSpace option, the WebSockets spec needs to be adjusted.
 
+NOTE: These proposed changes depend on WebSockets adding support for an options bag
+(see https://github.com/whatwg/websockets/pull/76).
+
   * Append an optional [=map/entry=] to {{WebSocketInit}}, whose [=map/key=] is
-    <dfn export>targetAddressSpace</dfn>, and [=map/value=] is a
+    targetAddressSpace`, and [=map/value=] is a
     {{IPAddressSpace}}.
       <pre class="idl">
         partial dictionary WebSocketInit {
@@ -839,9 +845,8 @@ To support the targetAddressSpace option, the WebSockets spec needs to be adjust
     to additionally take a targetAddressSpace parameter, and then when constructing the
     [=request=] |request| in step 2, set |request|'s targetAddressSpace to targetAddressSpace.
 
-  * Add the following steps to <a constructor for=WebSocket lt="WebSocket(url, protocolsOrOptions)">
-    <code>new WebSocket(<var ignore=''>url</var>, |protocolsOrOptions|)</code></a> after the steps
-    for handling protocols:
+  * Add the following steps to "`new WebSocket(url, protocolsOrOptions)` constructor steps"
+    after the steps for handling protocols:
     1. Let |targetAddressSpace| be an [=IP address space=], initially null.
     1.  If |protocolsOrOptions|["{{WebSocketInit/targetAddressSpace}}"] [=map/exists=], then
         switch on |protocolsOrOptions|["{{WebSocketInit/targetAddressSpace}}"]:
@@ -851,11 +856,13 @@ To support the targetAddressSpace option, the WebSockets spec needs to be adjust
           
           <dt>local
           <dd>Set |targetAddressSpace| to [=IP address space/local=].
+          <dt>loopback
+          <dd>Set |targetAddressSpace| to [=IP address space/loopback].
         </dl>
 
-  * Update the last step of <a constructor for=WebSocket lt="WebSocket(url, protocolsOrOptions)">
-    <code>new WebSocket(<var ignore=''>url</var>, |protocolsOrOptions|)</code></a> to:
-    1. [=Establish a WebSocket connection=] given |urlRecord|, |protocols|, |targetAddressSpace|, and |client|.
+  * Update the last step of the "`new WebSocket(url, protocolsOrOptions)` constructor steps" to:
+    1. [=websockets/Establish a WebSocket connection=] given <var ignore=''>urlRecord</var>,
+       <var ignore=''>protocols</var>, |targetAddressSpace|, and <var ignore=''>client</var>.
 
 ## Integration with WebTransport ## {#integration-with-webtransport}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 11, 2026, 10:35 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Flocal-network-access%2F332b714a7b9097fefc2fba899bc54be80f9d8f88%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "835:41",
        "messageType": "link",
        "text": "No 'idl' refs found for 'WebSocketInit'."
    },
    {
        "lineNum": "478:5",
        "messageType": "fatal",
        "text": "Couldn't find target document section rollout-difficulties:\n[[#rollout-difficulties]]"
    },
    {
        "lineNum": "504:16",
        "messageType": "fatal",
        "text": "Couldn't find target document section rollout-difficulties:\n[[#rollout-difficulties]]"
    },
    {
        "lineNum": "1224:47",
        "messageType": "fatal",
        "text": "Couldn't find target document section dns-rebinding:\n[[#dns-rebinding]]"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20WICG/local-network-access%23125.)._

</details>
